### PR TITLE
add limits to the photoSize property to address Issue #75

### DIFF
--- a/piwigo/Model.m
+++ b/piwigo/Model.m
@@ -80,6 +80,17 @@
 	return name;
 }
 
+#pragma mark - Getter -
+
+-(NSInteger)photoResize {
+    if (_photoResize < 1) {
+        _photoResize = 1;
+    } else if (_photoResize > 100) {
+        _photoResize = 100;
+    }
+    return _photoResize;
+}
+
 #pragma mark - Saving to Disk
 + (NSString *)applicationDocumentsDirectory
 {


### PR DESCRIPTION
The Model property photoSize should stay within the limits of 1 to 100. When the value of photoSize is outside the limits then it will be reset to the nearest limit.