### PR TITLE
Enhanced TagVC and fix for returning only first keyword

### DIFF
--- a/piwigo/EditImageDetailsViewController.m
+++ b/piwigo/EditImageDetailsViewController.m
@@ -233,9 +233,16 @@ typedef enum {
 	{
 		TagsViewController *tagsVC = [TagsViewController new];
 		tagsVC.delegate = self;
-		tagsVC.alreadySelectedTags = self.imageDetails.tags;
+		tagsVC.alreadySelectedTags = [self.imageDetails.tags mutableCopy];
 		[self.navigationController pushViewController:tagsVC animated:YES];
-	}
+    } else if (indexPath.row == EditImageDetailsOrderAuthor) {
+        if (0 == self.imageDetails.author.length) { // only update if not yet set, dont overwrite
+            if (0 < [[[Model sharedInstance] defaultAuthor] length]) { // must know the default author
+                self.imageDetails.author = [[Model sharedInstance] defaultAuthor];
+                [tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+            }
+        }
+    }
 	
 }
 

--- a/piwigo/PiwigoTagData.m
+++ b/piwigo/PiwigoTagData.m
@@ -10,4 +10,21 @@
 
 @implementation PiwigoTagData
 
+
+#pragma mark - debugging support -
+
+-(NSString *)description {
+    NSString *objectIsNil = @"<nil>";
+
+    NSMutableArray * descriptionArray = [[NSMutableArray alloc] init];
+    [descriptionArray addObject:[NSString stringWithFormat:@"<%@: 0x%lx> = {", [self class], (unsigned long)self]];
+    [descriptionArray addObject:[NSString stringWithFormat:@"tagName                = %@", (nil == self.tagName ? objectIsNil : (0 == [self.tagName length] ? @"''" : self.tagName))]];
+
+    [descriptionArray addObject:[NSString stringWithFormat:@"tagId                  = %ld", (long)self.tagId]];
+    [descriptionArray addObject:[NSString stringWithFormat:@"numberOfImagesUnderTag = %ld", (long)self.numberOfImagesUnderTag]];
+    [descriptionArray addObject:@"}"];
+    
+    return [descriptionArray componentsJoinedByString:@"\n"];
+}
+
 @end

--- a/piwigo/Resources/Localizable.strings
+++ b/piwigo/Resources/Localizable.strings
@@ -178,6 +178,12 @@
 
 "version" = "Version:";
 
+/* header over list of 'selected' keywords */
+"keywords_selected" = "Selected";
+
+/* header over list of 'all' available keywords */
+"keywords_all" = "All";
+
 // ----------------------- ERROR STRINGS -----------------------
 
 "error" = "Error";

--- a/piwigo/TagsData.m
+++ b/piwigo/TagsData.m
@@ -117,4 +117,16 @@
 	return count;
 }
 
+#pragma mark - debugging support -
+
+-(NSString *)description {
+    NSMutableArray * descriptionArray = [[NSMutableArray alloc] init];
+    [descriptionArray addObject:[NSString stringWithFormat:@"<%@: 0x%lx> = {", [self class], (unsigned long)self]];
+    
+    [descriptionArray addObject:[NSString stringWithFormat:@"tagList [%ld]  = %@", (long)self.tagList.count, self.tagList]];
+    [descriptionArray addObject:@"}"];
+    
+    return [descriptionArray componentsJoinedByString:@"\n"];
+}
+    
 @end

--- a/piwigo/TagsViewController.h
+++ b/piwigo/TagsViewController.h
@@ -17,6 +17,6 @@
 @interface TagsViewController : UIViewController
 
 @property (nonatomic, weak) id<TagsViewControllerDelegate> delegate;
-@property (nonatomic, strong) NSArray *alreadySelectedTags;
+@property (nonatomic, strong) NSMutableArray *alreadySelectedTags;
 
 @end

--- a/piwigo/TagsViewController.m
+++ b/piwigo/TagsViewController.m
@@ -13,7 +13,7 @@
 @interface TagsViewController () <UITableViewDelegate, UITableViewDataSource>
 
 @property (nonatomic, strong) UITableView *tagsTableView;
-@property (nonatomic, strong) NSMutableArray *selectedIndices;
+@property (nonatomic, strong) NSArray *letterIndex;
 
 @end
 
@@ -26,9 +26,7 @@
 	{
 		self.view.backgroundColor = [UIColor whiteColor];
 		self.title = NSLocalizedString(@"tags", @"Tags");
-		
-		self.selectedIndices = [NSMutableArray new];
-		
+				
 		self.tagsTableView = [UITableView new];
 		self.tagsTableView.translatesAutoresizingMaskIntoConstraints = NO;
 		self.tagsTableView.delegate = self;
@@ -37,6 +35,11 @@
 		[self.view addConstraints:[NSLayoutConstraint constraintFillSize:self.tagsTableView]];
 		
 		[[TagsData sharedInstance] getTagsOnCompletion:^(NSArray *tags) {
+            NSMutableSet *firstCharacters = [NSMutableSet setWithCapacity:0];
+            for( NSString *string in [[TagsData sharedInstance].tagList valueForKey:@"tagName"] )
+                [firstCharacters addObject:[[string substringToIndex:1] uppercaseString]];
+            
+            self.letterIndex = [[firstCharacters allObjects] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
 			[self.tagsTableView reloadData];
 		}];
 		
@@ -50,44 +53,57 @@
 	
 	if([self.delegate respondsToSelector:@selector(didExitWithSelectedTags:)])
 	{
-		NSMutableArray *selectedTags = [NSMutableArray new];
-		
-		for(NSNumber *selectedIndex in self.selectedIndices)
-		{
-			[selectedTags addObject:[TagsData sharedInstance].tagList[[selectedIndex integerValue]]];
-		}
-		
-		[self.delegate didExitWithSelectedTags:selectedTags];
+		[self.delegate didExitWithSelectedTags:self.alreadySelectedTags];
 	}
 }
 
--(void)setAlreadySelectedTags:(NSArray *)alreadySelectedTags
-{
-	_alreadySelectedTags = alreadySelectedTags;
-	
-	for(PiwigoTagData *tagData in alreadySelectedTags)
-	{
-		[self.selectedIndices addObject:@([[TagsData sharedInstance] getIndexOfTag:tagData])];
-	}
+#pragma mark - Abcindex -
+
+- (NSArray *)sectionIndexTitlesForTableView:(UITableView *)tableView {
+    return self.letterIndex;
 }
 
--(void)addOrRemoveIndexToSelected:(NSInteger)index
+- (NSInteger)tableView:(UITableView *)tableView sectionForSectionIndexTitle:(NSString *)title atIndex:(NSInteger)index {
+    
+    NSInteger newRow = [self indexForFirstChar:title inArray:[[TagsData sharedInstance].tagList valueForKey:@"tagName"]];
+    NSIndexPath *newIndexPath = [NSIndexPath indexPathForRow:newRow inSection:1];
+    [tableView scrollToRowAtIndexPath:newIndexPath atScrollPosition:UITableViewScrollPositionTop animated:NO];
+    
+    return index;
+}
+
+// Return the index of the first occurence of an item that begins with the supplied character
+- (NSInteger)indexForFirstChar:(NSString *)character inArray:(NSArray *)array
 {
-	if(![self.selectedIndices containsObject:@(index)])
-	{
-		[self.selectedIndices addObject:@(index)];
-	}
-	else
-	{
-		[self.selectedIndices removeObject:@(index)];
-	}
+    NSUInteger count = 0;
+    for (NSString *aString in array) {
+        if ([aString hasPrefix:character]) {
+            return count;
+        }
+        count++;
+    }
+    return 0;
 }
 
 #pragma mark UITableView Methods
+-(NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
+    if (section == 0) {
+        return NSLocalizedString(@"keywords_selected", @"Selected");
+    } else {
+        return NSLocalizedString(@"keywords_all", @"All");
+    }
+}
+-(NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return 2;
+}
 
 -(NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-	return [TagsData sharedInstance].tagList.count;
+    if (section == 0) {
+        return self.alreadySelectedTags.count;
+    } else {
+        return [TagsData sharedInstance].tagList.count;
+    }
 }
 
 -(UITableViewCell*)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
@@ -97,28 +113,56 @@
 	{
 		cell = [UITableViewCell new];
 	}
-	
-	cell.textLabel.text = [[TagsData sharedInstance].tagList[indexPath.row] tagName];
-	
-	if([self.selectedIndices containsObject:@(indexPath.row)])
-	{
-		cell.accessoryType = UITableViewCellAccessoryCheckmark;
-	}
-	else
-	{
-		cell.accessoryType = UITableViewCellAccessoryNone;
-	}
-	
-	return cell;
+    PiwigoTagData *currentTag;
+    if (indexPath.section == 0) {
+        currentTag = self.alreadySelectedTags[indexPath.row];
+    } else {
+        currentTag = [TagsData sharedInstance].tagList[indexPath.row];
+    }
+    
+        cell.textLabel.text = currentTag.tagName;
+        
+    NSArray *selectedTagIDs = [self.alreadySelectedTags valueForKey:@"tagId"];
+    if ([selectedTagIDs containsObject:@(currentTag.tagId)]) {
+        cell.accessoryType = UITableViewCellAccessoryCheckmark;
+    } else {
+        cell.accessoryType = UITableViewCellAccessoryNone;
+    }
+
+    return cell;
 }
 
 -(void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
 	[tableView deselectRowAtIndexPath:indexPath animated:YES];
-	
-	[self addOrRemoveIndexToSelected:indexPath.row];
-	
-	[tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+    PiwigoTagData *currentTag;
+    if (indexPath.section == 0) { // delete tag if tapped
+        [self.alreadySelectedTags removeObjectAtIndex:indexPath.row];
+        [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+    } else { // add if not yet selected or remove if already selected
+        currentTag = [TagsData sharedInstance].tagList[indexPath.row];
+        NSUInteger indexOfSelection = [self.alreadySelectedTags indexOfObjectPassingTest:^BOOL(PiwigoTagData *someTag, NSUInteger idx, BOOL *stop) {
+            return (someTag.tagId == currentTag.tagId);
+        }];
+        
+        if (NSNotFound == indexOfSelection ) { // add if not yet selected
+            [self.alreadySelectedTags addObject:currentTag];
+            [self.alreadySelectedTags sortUsingDescriptors:
+             [NSArray arrayWithObjects:
+              [NSSortDescriptor sortDescriptorWithKey:@"tagName" ascending:YES], nil]];
+
+            NSIndexPath *somePath = [NSIndexPath indexPathForRow:(self.alreadySelectedTags.count - 1) inSection:0];
+            [tableView insertRowsAtIndexPaths:@[somePath] withRowAnimation:UITableViewRowAnimationAutomatic];
+            NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:0];
+            [tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+        } else { // remove if already selected
+            [self.alreadySelectedTags removeObject:currentTag];
+            NSIndexPath *removePath = [NSIndexPath indexPathForRow:indexOfSelection inSection:0];
+            [tableView deleteRowsAtIndexPaths:@[removePath] withRowAnimation:UITableViewRowAnimationAutomatic];
+        }
+        // update the checkmark
+        [tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+    }
 }
 
 @end


### PR DESCRIPTION
In certain circumstances the TagViewController will return the first available tag (keyword). This is a fix for it.
When the list of keywords is getting long requires much scrolling of the list to select keywords. This enhancement  adds an index on the right of the table to quickly jump to a tag. Also it adds a section on the top of the table showing the currently selected keyword.

Minor enhancement: In EditImageDetailsVC when Author field is empty a tap on the row (not the textfield) will pull the default authors name from settings. A tap on the textfield will open the keyboard as before.

- added description to TagsData and PiwigoTagData