### PR TITLE
Version 2.1.3 build 63

### DIFF
--- a/piwigo.xcodeproj/project.pbxproj
+++ b/piwigo.xcodeproj/project.pbxproj
@@ -137,6 +137,11 @@
 		AD45949C1F36765200CF9438 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/About.strings; sourceTree = "<group>"; };
 		AD45949D1F36765200CF9438 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/ReleaseNotes.strings; sourceTree = "<group>"; };
 		AD45949E1F36765200CF9438 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/AppStore.strings; sourceTree = "<group>"; };
+		AD591A391F9116F9008D02B6 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		AD591A3A1F9116FA008D02B6 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/About.strings; sourceTree = "<group>"; };
+		AD591A3B1F9116FA008D02B6 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/ReleaseNotes.strings; sourceTree = "<group>"; };
+		AD591A3C1F9116FA008D02B6 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/AppStore.strings; sourceTree = "<group>"; };
+		AD591A3D1F9116FA008D02B6 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		AD6B2E741F0930B40040EAD9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		AD6B2E771F0930CE0040EAD9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/About.strings; sourceTree = "<group>"; };
 		AD6B2E791F0930FD0040EAD9 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -942,6 +947,7 @@
 				fr,
 				da,
 				pl,
+				de,
 			);
 			mainGroup = D82B8CB21A67820A000E47CA;
 			productRefGroup = D82B8CBC1A67820A000E47CA /* Products */;
@@ -1205,6 +1211,7 @@
 				AD294B2A1F2CE87400CD3769 /* fr */,
 				AD3FDDEB1F2E23F700F71C81 /* da */,
 				AD45949E1F36765200CF9438 /* pl */,
+				AD591A3C1F9116FA008D02B6 /* de */,
 			);
 			name = AppStore.strings;
 			sourceTree = "<group>";
@@ -1225,6 +1232,7 @@
 				AD6B2E791F0930FD0040EAD9 /* fr */,
 				AD3FDDE81F2E23F700F71C81 /* da */,
 				AD45949B1F36765200CF9438 /* pl */,
+				AD591A391F9116F9008D02B6 /* de */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -1236,6 +1244,7 @@
 				AD6B2E7A1F0930FD0040EAD9 /* fr */,
 				AD3FDDE91F2E23F700F71C81 /* da */,
 				AD45949C1F36765200CF9438 /* pl */,
+				AD591A3A1F9116FA008D02B6 /* de */,
 			);
 			name = About.strings;
 			sourceTree = "<group>";
@@ -1247,6 +1256,7 @@
 				AD92B9011F200092006E5B63 /* fr */,
 				AD3FDDEA1F2E23F700F71C81 /* da */,
 				AD45949D1F36765200CF9438 /* pl */,
+				AD591A3B1F9116FA008D02B6 /* de */,
 			);
 			name = ReleaseNotes.strings;
 			sourceTree = "<group>";
@@ -1258,6 +1268,7 @@
 				ADC06AE21F40B1ED0081B4FA /* fr */,
 				ADC06AE31F40B2BB0081B4FA /* da */,
 				ADC06AE41F40B2BC0081B4FA /* pl */,
+				AD591A3D1F9116FA008D02B6 /* de */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";

--- a/piwigo/Albums/Album List/Album Edit/MoveCategoryViewController.m
+++ b/piwigo/Albums/Album List/Album Edit/MoveCategoryViewController.m
@@ -164,7 +164,8 @@
                                 preferredStyle:UIAlertControllerStyleAlert];
     
     UIAlertAction* dismissAction = [UIAlertAction
-                                    actionWithTitle:NSLocalizedString(@"alertDismissButton", @"Dismiss") style:UIAlertActionStyleCancel
+                                    actionWithTitle:NSLocalizedString(@"alertDismissButton", @"Dismiss")
+                                    style:UIAlertActionStyleCancel
                                     handler:^(UIAlertAction * action) {}];
     
     [alert addAction:dismissAction];

--- a/piwigo/Albums/Album List/Album Edit/MoveCategoryViewController.m
+++ b/piwigo/Albums/Album List/Album Edit/MoveCategoryViewController.m
@@ -187,11 +187,16 @@
     // Change the background view shape, style and color.
     hud.square = NO;
     hud.animationType = MBProgressHUDAnimationFade;
-    hud.contentColor = [UIColor piwigoWhiteCream];
-    hud.bezelView.color = [UIColor colorWithWhite:0.f alpha:1.0];
     hud.backgroundView.style = MBProgressHUDBackgroundStyleSolidColor;
     hud.backgroundView.color = [UIColor colorWithWhite:0.f alpha:0.5f];
-    
+    if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_9_x_Max) {
+        hud.contentColor = [UIColor piwigoWhiteCream];
+        hud.bezelView.color = [UIColor colorWithWhite:0.f alpha:1.0];
+    } else {
+        hud.contentColor = [UIColor piwigoGray];
+        hud.bezelView.color = [UIColor piwigoGrayLight];
+    }
+
     // Define the text
     hud.label.text = NSLocalizedString(@"moveCategoryHUD_moving", @"Moving Album…");
     hud.label.font = [UIFont piwigoFontNormal];

--- a/piwigo/Albums/Album List/AlbumTableViewCell.m
+++ b/piwigo/Albums/Album List/AlbumTableViewCell.m
@@ -598,11 +598,16 @@
     // Change the background view shape, style and color.
     hud.square = NO;
     hud.animationType = MBProgressHUDAnimationFade;
-    hud.contentColor = [UIColor piwigoWhiteCream];
-    hud.bezelView.color = [UIColor colorWithWhite:0.f alpha:1.0];
     hud.backgroundView.style = MBProgressHUDBackgroundStyleSolidColor;
     hud.backgroundView.color = [UIColor colorWithWhite:0.f alpha:0.5f];
-    
+    if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_9_x_Max) {
+        hud.contentColor = [UIColor piwigoWhiteCream];
+        hud.bezelView.color = [UIColor colorWithWhite:0.f alpha:1.0];
+    } else {
+        hud.contentColor = [UIColor piwigoGray];
+        hud.bezelView.color = [UIColor piwigoGrayLight];
+    }
+
     // Define the text
     hud.label.text = label;
     hud.label.font = [UIFont piwigoFontNormal];

--- a/piwigo/Albums/Album List/AlbumsViewController.m
+++ b/piwigo/Albums/Album List/AlbumsViewController.m
@@ -232,11 +232,16 @@ static SEL extracted() {
     // Change the background view shape, style and color.
     hud.square = NO;
     hud.animationType = MBProgressHUDAnimationFade;
-    hud.contentColor = [UIColor piwigoWhiteCream];
-    hud.bezelView.color = [UIColor colorWithWhite:0.f alpha:1.0];
     hud.backgroundView.style = MBProgressHUDBackgroundStyleSolidColor;
     hud.backgroundView.color = [UIColor colorWithWhite:0.f alpha:0.5f];
-    
+    if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_9_x_Max) {
+        hud.contentColor = [UIColor piwigoWhiteCream];
+        hud.bezelView.color = [UIColor colorWithWhite:0.f alpha:1.0];
+    } else {
+        hud.contentColor = [UIColor piwigoGray];
+        hud.bezelView.color = [UIColor piwigoGrayLight];
+    }
+
     // Define the text
     hud.label.text = NSLocalizedString(@"createNewAlbumHUD_label", @"Creating Album…");
     hud.label.font = [UIFont piwigoFontNormal];

--- a/piwigo/Albums/Album List/AlbumsViewController.m
+++ b/piwigo/Albums/Album List/AlbumsViewController.m
@@ -99,6 +99,7 @@ static SEL extracted() {
 	refreshControl.tintColor = [UIColor piwigoGray];
 	[refreshControl addTarget:self action:@selector(refresh:) forControlEvents:UIControlEventValueChanged];
 	[self.albumsTableView addSubview:refreshControl];
+    self.albumsTableView.alwaysBounceVertical = YES;
 	
     [self getAlbumData];
 	[self refreshShowingCells];

--- a/piwigo/Albums/Album List/AlbumsViewController.m
+++ b/piwigo/Albums/Album List/AlbumsViewController.m
@@ -209,7 +209,8 @@ static SEL extracted() {
                                 preferredStyle:UIAlertControllerStyleAlert];
     
     UIAlertAction* dismissAction = [UIAlertAction
-                                    actionWithTitle:NSLocalizedString(@"alertDismissButton", @"Dismiss") style:UIAlertActionStyleCancel
+                                    actionWithTitle:NSLocalizedString(@"alertDismissButton", @"Dismiss")
+                                    style:UIAlertActionStyleCancel
                                     handler:^(UIAlertAction * action) {}];
     
     [alert addAction:dismissAction];

--- a/piwigo/Albums/Album Pictures/AlbumImagesViewController.m
+++ b/piwigo/Albums/Album Pictures/AlbumImagesViewController.m
@@ -135,7 +135,8 @@
 	refreshControl.tintColor = [UIColor piwigoGray];
 	refreshControl.attributedTitle = [[NSAttributedString alloc] initWithString:NSLocalizedString(@"pullToRefresh", @"Loading All Images")];
 	[refreshControl addTarget:self action:@selector(refresh:) forControlEvents:UIControlEventValueChanged];
-    self.imagesCollection.refreshControl = refreshControl;
+    [self.imagesCollection addSubview:refreshControl];
+    self.imagesCollection.alwaysBounceVertical = YES;
 }
 
 -(void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator{
@@ -455,7 +456,7 @@
                          }
                   completionHandler:^(NSURLResponse *response, NSURL *filePath, NSError *error) {
                       // Any error ?
-                      if (!error.code) {
+                      if (error.code) {
 #if defined(DEBUG)
                           NSLog(@"AlbumImagesViewController: downloadImage fail");
 #endif

--- a/piwigo/Albums/Album Pictures/AlbumImagesViewController.m
+++ b/piwigo/Albums/Album Pictures/AlbumImagesViewController.m
@@ -353,7 +353,8 @@
                                     preferredStyle:UIAlertControllerStyleAlert];
         
         UIAlertAction* dismissAction = [UIAlertAction
-                                        actionWithTitle:NSLocalizedString(@"alertDismissButton", @"Dismiss") style:UIAlertActionStyleCancel
+                                        actionWithTitle:NSLocalizedString(@"alertDismissButton", @"Dismiss")
+                                        style:UIAlertActionStyleCancel
                                         handler:^(UIAlertAction * action) {}];
         
         [alert addAction:dismissAction];

--- a/piwigo/Albums/Album Thumbnail/AllCategoriesViewController.m
+++ b/piwigo/Albums/Album Thumbnail/AllCategoriesViewController.m
@@ -220,11 +220,16 @@
     // Change the background view shape, style and color.
     hud.square = NO;
     hud.animationType = MBProgressHUDAnimationFade;
-    hud.contentColor = [UIColor piwigoWhiteCream];
-    hud.bezelView.color = [UIColor colorWithWhite:0.f alpha:1.0];
     hud.backgroundView.style = MBProgressHUDBackgroundStyleSolidColor;
     hud.backgroundView.color = [UIColor colorWithWhite:0.f alpha:0.5f];
-    
+    if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_9_x_Max) {
+        hud.contentColor = [UIColor piwigoWhiteCream];
+        hud.bezelView.color = [UIColor colorWithWhite:0.f alpha:1.0];
+    } else {
+        hud.contentColor = [UIColor piwigoGray];
+        hud.bezelView.color = [UIColor piwigoGrayLight];
+    }
+
     // Define the text
     hud.label.text = NSLocalizedString(@"categoryImageSetHUD_updating", @"Updating Album Thumbnail…");
     hud.label.font = [UIFont piwigoFontNormal];

--- a/piwigo/Images/Image Detail/ImageDetailViewController.m
+++ b/piwigo/Images/Image Detail/ImageDetailViewController.m
@@ -286,7 +286,7 @@
                              
                              UIAlertAction* retryAction = [UIAlertAction
                                  actionWithTitle:NSLocalizedString(@"alertTryAgainButton", @"Try Again")
-                                 style:UIAlertActionStyleCancel
+                                 style:UIAlertActionStyleDefault
                                  handler:^(UIAlertAction * action) {
                                      [self downloadImage];
                                  }];
@@ -321,7 +321,7 @@
                           
                           UIAlertAction* retryAction = [UIAlertAction
                                                         actionWithTitle:NSLocalizedString(@"alertTryAgainButton", @"Try Again")
-                                                        style:UIAlertActionStyleCancel
+                                                        style:UIAlertActionStyleDefault
                                                         handler:^(UIAlertAction * action) {
                                                             [self downloadImage];
                                                         }];

--- a/piwigo/Images/Image Detail/ImagePreviewViewController.m
+++ b/piwigo/Images/Image Detail/ImagePreviewViewController.m
@@ -78,10 +78,12 @@
     if ((user != nil) && ([user length] > 0)) {
         NSString *password = [KeychainAccess getLoginPassword];
         [manager setTaskDidReceiveAuthenticationChallengeBlock:^NSURLSessionAuthChallengeDisposition(NSURLSession *session, NSURLSessionTask *task, NSURLAuthenticationChallenge *challenge, NSURLCredential *__autoreleasing *credential) {
-            // Supply requested credentials
-            *credential = [NSURLCredential credentialWithUser:user
-                                                     password:password
-                                                  persistence:NSURLCredentialPersistenceForSession];
+            // Supply requested credentials if not provided yet
+            if (challenge.previousFailureCount == 0) {
+                *credential = [NSURLCredential credentialWithUser:user
+                                                         password:password
+                                                      persistence:NSURLCredentialPersistenceForSession];
+            }
             return NSURLSessionAuthChallengeUseCredential;
         }];
     }

--- a/piwigo/Images/ImageService.m
+++ b/piwigo/Images/ImageService.m
@@ -259,10 +259,12 @@ NSString * const kGetImageOrderDescending = @"desc";
     if ((user != nil) && ([user length] > 0)) {
         NSString *password = [KeychainAccess getLoginPassword];
         [manager setTaskDidReceiveAuthenticationChallengeBlock:^NSURLSessionAuthChallengeDisposition(NSURLSession *session, NSURLSessionTask *task, NSURLAuthenticationChallenge *challenge, NSURLCredential *__autoreleasing *credential) {
-            // Supply requested credentials
-            *credential = [NSURLCredential credentialWithUser:user
-                                                     password:password
-                                                  persistence:NSURLCredentialPersistenceForSession];
+            // Supply requested credentials if not provided yet
+            if (challenge.previousFailureCount == 0) {
+                *credential = [NSURLCredential credentialWithUser:user
+                                                         password:password
+                                                      persistence:NSURLCredentialPersistenceForSession];
+            }
             return NSURLSessionAuthChallengeUseCredential;
         }];
     }
@@ -309,10 +311,12 @@ NSString * const kGetImageOrderDescending = @"desc";
     if ((user != nil) && ([user length] > 0)) {
         NSString *password = [KeychainAccess getLoginPassword];
         [manager setTaskDidReceiveAuthenticationChallengeBlock:^NSURLSessionAuthChallengeDisposition(NSURLSession *session, NSURLSessionTask *task, NSURLAuthenticationChallenge *challenge, NSURLCredential *__autoreleasing *credential) {
-            // Supply requested credentials
-            *credential = [NSURLCredential credentialWithUser:user
-                                                     password:password
-                                                  persistence:NSURLCredentialPersistenceForSession];
+            // Supply requested credentials if not provided yet
+            if (challenge.previousFailureCount == 0) {
+                *credential = [NSURLCredential credentialWithUser:user
+                                                         password:password
+                                                      persistence:NSURLCredentialPersistenceForSession];
+            }
             return NSURLSessionAuthChallengeUseCredential;
         }];
     }

--- a/piwigo/Images/ImageService.m
+++ b/piwigo/Images/ImageService.m
@@ -133,7 +133,9 @@ NSString * const kGetImageOrderDescending = @"desc";
 	{
 		imageData.name = @"";
 	}
-    imageData.fullResPath = [imageJson objectForKey:@"element_url"];
+    // When $conf['original_url_protection'] = 'images' or 'all'; is enabled
+    // the URLs returned by the Piwigo server contain &amp; instead of & (Piwigo v2.9.2)
+    imageData.fullResPath = [[imageJson objectForKey:@"element_url"] stringByReplacingOccurrencesOfString:@"&amp;" withString:@"&"];
 	
 	imageData.privacyLevel = [[imageJson objectForKey:@"level"] integerValue];
 	imageData.author = [imageJson objectForKey:@"author"];
@@ -154,16 +156,18 @@ NSString * const kGetImageOrderDescending = @"desc";
     dateString = [imageJson objectForKey:@"date_creation"];
     if (![dateString isKindOfClass:[NSNull class]]) imageData.dateCreated = [dateFormat dateFromString:dateString];
     
+    // When $conf['original_url_protection'] = 'images' or 'all'; is enabled
+    // the URLs returned by the Piwigo server contain &amp; instead of & (Piwigo v2.9.2)
 	NSDictionary *imageSizes = [imageJson objectForKey:@"derivatives"];
-	imageData.SquarePath = [[imageSizes objectForKey:@"square"] objectForKey:@"url"];
-	imageData.ThumbPath = [[imageSizes objectForKey:@"thumb"] objectForKey:@"url"];
-	imageData.MediumPath = [[imageSizes objectForKey:@"medium"] objectForKey:@"url"];
-	imageData.XXSmallPath = [imageSizes valueForKeyPath:@"2small.url"];
-	imageData.XSmallPath = [imageSizes valueForKeyPath:@"xsmall.url"];
-	imageData.SmallPath = [imageSizes valueForKeyPath:@"small.url"];
-	imageData.LargePath = [imageSizes valueForKeyPath:@"large.url"];
-	imageData.XLargePath = [imageSizes valueForKeyPath:@"xlarge.url"];
-	imageData.XXLargePath = [imageSizes valueForKeyPath:@"xxlarge.url"];
+	imageData.SquarePath = [[[imageSizes objectForKey:@"square"] objectForKey:@"url"] stringByReplacingOccurrencesOfString:@"&amp;" withString:@"&"];
+	imageData.ThumbPath = [[[imageSizes objectForKey:@"thumb"] objectForKey:@"url"] stringByReplacingOccurrencesOfString:@"&amp;" withString:@"&"];
+	imageData.MediumPath = [[[imageSizes objectForKey:@"medium"] objectForKey:@"url"] stringByReplacingOccurrencesOfString:@"&amp;" withString:@"&"];
+	imageData.XXSmallPath = [[imageSizes valueForKeyPath:@"2small.url"] stringByReplacingOccurrencesOfString:@"&amp;" withString:@"&"];
+	imageData.XSmallPath = [[imageSizes valueForKeyPath:@"xsmall.url"] stringByReplacingOccurrencesOfString:@"&amp;" withString:@"&"];
+	imageData.SmallPath = [[imageSizes valueForKeyPath:@"small.url"] stringByReplacingOccurrencesOfString:@"&amp;" withString:@"&"];
+	imageData.LargePath = [[imageSizes valueForKeyPath:@"large.url"] stringByReplacingOccurrencesOfString:@"&amp;" withString:@"&"];
+	imageData.XLargePath = [[imageSizes valueForKeyPath:@"xlarge.url"] stringByReplacingOccurrencesOfString:@"&amp;" withString:@"&"];
+	imageData.XXLargePath = [[imageSizes valueForKeyPath:@"xxlarge.url"] stringByReplacingOccurrencesOfString:@"&amp;" withString:@"&"];
 	
 	NSArray *categories = [imageJson objectForKey:@"categories"];
 	NSMutableArray *categoryIds = [NSMutableArray new];

--- a/piwigo/Info.plist
+++ b/piwigo/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>62</string>
+	<string>63</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/piwigo/Info.plist
+++ b/piwigo/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>61</string>
+	<string>62</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/piwigo/Login/LoginViewController.m
+++ b/piwigo/Login/LoginViewController.m
@@ -440,10 +440,15 @@
         // Change the background view shape, style and color.
         hud.square = NO;
         hud.animationType = MBProgressHUDAnimationFade;
-        hud.contentColor = [UIColor piwigoWhiteCream];
-        hud.bezelView.color = [UIColor colorWithWhite:0.f alpha:1.0];
         hud.backgroundView.style = MBProgressHUDBackgroundStyleSolidColor;
         hud.backgroundView.color = [UIColor colorWithWhite:0.f alpha:0.5f];
+        if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_9_x_Max) {
+            hud.contentColor = [UIColor piwigoWhiteCream];
+            hud.bezelView.color = [UIColor colorWithWhite:0.f alpha:1.0];
+        } else {
+            hud.contentColor = [UIColor piwigoGray];
+            hud.bezelView.color = [UIColor piwigoGrayLight];
+        }
         
         // Set title
         hud.label.text = NSLocalizedString(@"login_loggingIn", @"Logging In...");

--- a/piwigo/Network/NetworkHandler.m
+++ b/piwigo/Network/NetworkHandler.m
@@ -94,10 +94,12 @@ NSInteger const loadingViewTag = 899;
         [manager setTaskDidReceiveAuthenticationChallengeBlock:^NSURLSessionAuthChallengeDisposition(NSURLSession *session, NSURLSessionTask *task, NSURLAuthenticationChallenge *challenge, NSURLCredential *__autoreleasing *credential) {
             // To remember app recieved anthentication challenge
             [Model sharedInstance].performedHTTPauthentication = YES;
-            // Supply requested credentials
-            *credential = [NSURLCredential credentialWithUser:user
-                                                     password:password
-                                                  persistence:NSURLCredentialPersistenceForSession];
+            // Supply requested credentials if not provided yet
+            if (challenge.previousFailureCount == 0) {
+                *credential = [NSURLCredential credentialWithUser:user
+                                                         password:password
+                                                      persistence:NSURLCredentialPersistenceForSession];
+            }
             return NSURLSessionAuthChallengeUseCredential;
         }];
     }
@@ -152,10 +154,12 @@ NSInteger const loadingViewTag = 899;
         [manager setTaskDidReceiveAuthenticationChallengeBlock:^NSURLSessionAuthChallengeDisposition(NSURLSession *session, NSURLSessionTask *task, NSURLAuthenticationChallenge *challenge, NSURLCredential *__autoreleasing *credential) {
             // To remember app recieved anthentication challenge
             [Model sharedInstance].performedHTTPauthentication = YES;
-            // Supply requested credentials
-            *credential = [NSURLCredential credentialWithUser:user
-                                                     password:password
-                                                  persistence:NSURLCredentialPersistenceForSession];
+            // Supply requested credentials if not provided yet
+            if (challenge.previousFailureCount == 0) {
+                *credential = [NSURLCredential credentialWithUser:user
+                                                         password:password
+                                                      persistence:NSURLCredentialPersistenceForSession];
+            }
             return NSURLSessionAuthChallengeUseCredential;
         }];
     }

--- a/piwigo/Resources/Base.lproj/About.strings
+++ b/piwigo/Resources/Base.lproj/About.strings
@@ -10,7 +10,7 @@
 "authors2" = "and Eddy Lelièvre-Berna";
 "version" = "Version:";
 
-"translators_text" = "We sincerely thank the following users for contributing their time and efforts in translating Piwigo: Thomas Christfort (Danish), Robert Mulder (Dutch), Michał Majchrowicz (Polish).\n\n";
+"translators_text" = "We sincerely thank the following users for contributing their time and efforts in translating Piwigo: Thomas Christfort (Danish), Jörg Knoerchen (German), Robert Mulder (Dutch), Michał Majchrowicz (Polish).\n\n";
 
 "about_text" = "This software contains some third party software that are redistributed under the terms and conditions of their original licenses.\n\n";
 

--- a/piwigo/Resources/da.lproj/About.strings
+++ b/piwigo/Resources/da.lproj/About.strings
@@ -10,7 +10,7 @@
 "authors2" = "og Eddy Lelièvre-Berna";
 "version" = "Version:";
 
-"translators_text" = "Stor tak til følgende brugere for deres tid og indsats ved oversættelse af Piwigo: Thomas Christfort (Dansk), Robert Mulder (Hollandsk), Michał Majchrowicz (Polsk).\n\n";
+"translators_text" = "Stor tak til følgende brugere for deres tid og indsats ved oversættelse af Piwigo: Thomas Christfort (Dansk), Jörg Knoerchen (Tysk), Robert Mulder (Hollandsk), Michał Majchrowicz (Polsk).\n\n";
 
 "about_text" = "Denne software indeholder tredjepartssoftware, som er videredistribueret under vilkår og betingelser for deres oprindelige licenser.\n\n";
 

--- a/piwigo/Resources/da.lproj/Localizable.strings
+++ b/piwigo/Resources/da.lproj/Localizable.strings
@@ -23,7 +23,7 @@
 "alertCancelButton" = "Fortryd";
 "alertAddButton" = "Tilføj";
 "alertRetryButton" = "Retry";
-"alertNextButton" = "Next Image";
+"alertNextButton" = "Næste billede";
 
 // Complete views
 "Complete" = "Udført";
@@ -35,9 +35,9 @@
 // Errors
 "internetErrorGeneral_title" = "Forbindelsesfejl";
 "internetErrorGeneral_broken" = "Forbindelsen blev afbrudt. \nPrøv at logge ind igen.";
-"internetCancellingConnection_button" = "Cancelling Connection…";
-"internetCancelledConnection_button" = "Cancel Connection";
-"internetCancelledConnection_title" = "Connection Cancelled";
+"internetCancellingConnection_button" = "Annullerer forbindelsen…";
+"internetCancelledConnection_button" = "Annuller forbindelsen";
+"internetCancelledConnection_title" = "Forbindelsen afbrudt";
 
 // ===========================================================================
 // ==> LOGIN / LOGOUT
@@ -49,10 +49,10 @@
 "login_passwordPlaceholder" = "Adgangskode (valgfrit)";
 "login_loggingIn" = "Logger ind...";
 "login_protocolDescription" = "(tryk for at ændre)";
-"login_connecting" = "Connecting";
-"login_newSession" = "Opening Session";
+"login_connecting" = "Forbinder";
+"login_newSession" = "Åbner session";
 "login_communityParameters" = "Community parametre";
-"login_serverParameters" = "Piwigo parametre";
+"login_serverParameters" = "Piwigo Parametre";
 "login_connectionChanged" = "Forbindelsen ændret!";
 
 // Login — Errors
@@ -107,10 +107,10 @@
 "categorySort_imagesOnly" = "Kun Billeder";
 
 // Album create
-"createNewAlbum_title" = "New Album";
-"createNewAlbum_message" = "Enter a name for this album.";
+"createNewAlbum_title" = "Nyt Album";
+"createNewAlbum_message" = "Indtast navm for dette album.";
 "createNewAlbum_placeholder" = "Navn på album";
-"createNewAlbumHUD_label" = "Creating Album…";
+"createNewAlbumHUD_label" = "Opretter album…";
 
 // Album create — Errors
 "createAlbumError_title" = "Opret Album Fejl";
@@ -123,9 +123,9 @@
 
 // Album rename
 "renameCategory_title" = "Omdøb Album";
-"renameCategory_message" = "Enter a new name for this album";
+"renameCategory_message" = "Indtast navn for dette album";
 "renameCategory_button" = "Omdøb";
-"renameCategoryHUD_label" = "Renaming Album…";
+"renameCategoryHUD_label" = "Omdøber Album…";
 
 // Album rename — Errors
 "renameCategoyError_title" = "Kunne ikke omdøbe album";
@@ -137,7 +137,7 @@
 "deleteCategoryConfirm_title" = "Er du sikker?";
 "deleteCategoryConfirm_message" = "Angiv antallet af billeder for at slette dette album\nAntal billeder: %@";
 "deleteCategoryConfirm_deleteButton" = "SLET";
-"deleteCategoryHUD_label" = "Deleting Album…";
+"deleteCategoryHUD_label" = "Sletter album…";
 
 // Album delete — errors
 "deleteCategoryMatchError_title" = "Antal stemmer ikke overens";
@@ -149,7 +149,7 @@
 "moveCategory" = "Flyt Album";
 "moveCategory_selectParent" = "Vælg et album at flytte albummet \"%@\" ind i";
 "moveCategory_message" = "Er du sikker på du vil flytte \"%@\" til albummet \"%@\"?";
-"moveCategoryHUD_moving" = "Moving Album…";
+"moveCategoryHUD_moving" = "Flytter album…";
 
 // album move — Errors
 "moveCategoryError_title" = "Kunne ikke flytte album";
@@ -160,7 +160,7 @@
 "categorySelection_forImage" = "Vælg et album for dette billede";
 "categoryImageSet_title" = "Vælg Miniaturebilledet";
 "categoryImageSet_message" = "Er du sikker på, at du vil bruge dette billede som miniaturebillede for albummet \"%@\"?";
-"categoryImageSetHUD_updating" = "Updating Album Thumbnail…";
+"categoryImageSetHUD_updating" = "Opdaterer Album miniature…";
 
 // Album set image thumbnail — Errors
 "categoryImageSetError_title" = "Billede Set fejl";
@@ -188,18 +188,18 @@
 "imageOptions_setAlbumImage" = "Angiv som Albumbillede";
 
 // Image details
-"imageDetailsView_title" = "Image Details";
+"imageDetailsView_title" = "Billeddetaljer";
 "editImageDetails_title" = "Titel:";
 "editImageDetails_titlePlaceholder" = "Titel";
 "editImageDetails_author" = "Forfatter:";
 "editImageDetails_tags" = "Etiketter:";
 "editImageDetails_privacyLevel" = "Hvem kan se dette billede?";
 "editImageDetails_descriptionPlaceholder" = "Beskrivelse";
-"editImageDetailsHUD_updating" = "Updating Image Info…";
+"editImageDetailsHUD_updating" = "Opdaterer billedinfo...";
 
 // Image details — Errors
-"editImageDetailsError_title" = "Failed to Update";
-"editImageDetailsError_message" = "Failed to update your changes with your server.\nTry again?";
+"editImageDetailsError_title" = "Kunne ikke opdatere";
+"editImageDetailsError_message" = "Kunne ikke opdatere dine ændringer på din server. \nPrøv igen?";
 "imageDetailsFetchError_title" = "Kan ikke læse billeddetajler";
 "imageDetailsFetchError_retryMessage" = "Hentning af billeddata mislykkedes, prøv igen?";
 "imageDetailsFetchError_continueMessage" = "Hentning af billeddata mislykkedes.\nFortsæt?";
@@ -275,7 +275,7 @@
 "imageUploadTableCell_uploading" = "Uploader...";
 "imageUploadProgressBar_zero" = "Uploader 0/0";
 "imageUploadProgressBar_nonZero" = "Uploader %@/%@";
-"imageUploadProgressBar_completed" = "Completed";
+"imageUploadProgressBar_completed" = "Fuldført";
 "imageUploadCompleted_title" = "Upload Fuldført";
 "imageUploadCompleted_message" = "billede/video uploadet til Piwigo server.";
 "imageUploadCompleted_message>1" = "billeder/videoer uploadet til Piwigo server.";

--- a/piwigo/Resources/da.lproj/ReleaseNotes.strings
+++ b/piwigo/Resources/da.lproj/ReleaseNotes.strings
@@ -6,7 +6,7 @@
  Copyright © 2017 Piwigo.org. All rights reserved.
  */
 
-"v2.1.3_text" = "Version 2.1.3\n\n• Add basic access authentication\n• Allow cancelling auto-connection\n• Improve interface and upload management\n• Improve translations and iOS 11 compatibility\n• Fix bug encountered with \"Not uploaded\" filter\n• Code modernization\n________________________________________\n\n";
+"v2.1.3_text" = "Version 2.1.2\n\n• Tilføjet grundlæggende adgangskontrol\n• Tilføjet afbrydelse af autoforbindelse\n• Forbedring af brugergrænseflade og upload\n• Forbedret oversættelse og iOS 11 kompabilitet\n• Rettet fejl ved \"ikke overført\" filter\n• Modernisering af kode\n________________________________________\n\n";
 
 "v2.1.2_text" = "Version 2.1.2\n7 september 2017\n\n• Rettelse af fejl i forbindelse med login ved Community versioner < 2,9 \n• Forbedrede oversættelser \n• Vedligeholdelses arbejde\n________________________________________\n\n";
 

--- a/piwigo/Resources/de.lproj/About.strings
+++ b/piwigo/Resources/de.lproj/About.strings
@@ -1,0 +1,27 @@
+/* 
+  About.strings
+  piwigo
+
+  Created by Spencer Baker on 2/19/15.
+  Copyright (c) 2015 bakercrew. All rights reserved.
+*/
+
+"authors1" = "Von Spencer Baker, Olaf Greck,";
+"authors2" = "und Eddy Lelièvre-Berna";
+"version" = "Version:";
+
+"translators_text" = "Wir danken den folgenden Benutzern herzlich für ihre Zeit und ihre Bemühungen bei der Übersetzung von Piwigo: Thomas Christfort (Danish), Jörg Knoerchen (Deutsch), Robert Mulder (Dutch), Michał Majchrowicz (Polish).\n\n";
+
+"about_text" = "Diese Software enthält Drittanbieter-Software, die unter den allgemeinen Geschäftsbedingungen ihrer ursprünglichen Lizenzen wiederverwendet werden.\n\n";
+
+"licenceMIT_text" = "MIT-Lizenz (MIT)\n\nHiermit wird unentgeltlich jeder Person, die eine Kopie der Software und der zugehörigen Dokumentationen (die \"Software\") erhält, die Erlaubnis erteilt, sie uneingeschränkt zu nutzen, inklusive und ohne Ausnahme mit dem Recht, sie zu verwenden, zu kopieren, zu verändern, zusammenzufügen, zu veröffentlichen, zu verbreiten, zu unterlizenzieren und/oder zu verkaufen, und Personen, denen diese Software überlassen wird, diese Rechte zu verschaffen, unter den folgenden Bedingungen:\n\nDer obige Urheberrechtsvermerk und dieser Erlaubnisvermerk sind in allen Kopien oder Teilkopien der Software beizulegen.\n\nDIE SOFTWARE WIRD OHNE JEDE AUSDRÜCKLICHE ODER IMPLIZIERTE GARANTIE BEREITGESTELLT, EINSCHLIEẞLICH DER GARANTIE ZUR BENUTZUNG FÜR DEN VORGESEHENEN ODER EINEM BESTIMMTEN ZWECK SOWIE JEGLICHER RECHTSVERLETZUNG, JEDOCH NICHT DARAUF BESCHRÄNKT. IN KEINEM FALL SIND DIE AUTOREN ODER COPYRIGHTINHABER FÜR JEGLICHEN SCHADEN ODER SONSTIGE ANSPRÜCHE HAFTBAR ZU MACHEN, OB INFOLGE DER ERFÜLLUNG EINES VERTRAGES, EINES DELIKTES ODER ANDERS IM ZUSAMMENHANG MIT DER SOFTWARE ODER SONSTIGER VERWENDUNG DER SOFTWARE ENTSTANDEN.\n________________________________________\n\n";
+
+"licenceAFN_text" = "AFNetworking\n\nMIT Lizenz (MIT)\n\nCopyright © 2011-2016 Alamofire Software Foundation\n(http://alamofire.org/)\n________________________________________\n\n";
+
+"licenceIRate_text" = "iRate\n\nVersion 1.12.1\nCreated by Nick Lockwood on 26/01/2011.\nCopyright © 2011 Charcoal Design\n\nThis software is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.\n\nPermission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:\n\n1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.\n2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.\n3. This notice may not be removed or altered from any source distribution.\n________________________________________\n\n";
+
+"licenceMBProgHUD_text" = "MBProgressHUD\n\nThe MIT License (MIT)\n\nCopyright © 2009-2016 Matej Bukovinski\n________________________________________\n\n";
+
+"licenceMGSTC_text" = "MGSwipeTableCell\n\nThe MIT License (MIT)\n\nCopyright © 2016 Imanol Fernandez @MortimerGoro\n________________________________________\n\n";
+
+"licenceUICL_text" = "UICountingLabel\n\nThe MIT License (MIT)\n\nCopyright © 2013 Tim Gostony";

--- a/piwigo/Resources/de.lproj/AppStore.strings
+++ b/piwigo/Resources/de.lproj/AppStore.strings
@@ -1,0 +1,13 @@
+/* 
+  AppStore.strings
+  piwigo
+
+  Created by Eddy Lelièvre-Berna on 29/07/2017.
+  Copyright © 2017 Piwigo.org. All rights reserved.
+*/
+
+"description" = "Piwigo für iPhone/iPad/iPod ergänzt die Cloud Foto Galerie Software Piwigo (V2. 7 oder höher):\n• Durchsuche Deine Alben, \n• erstelle neue Alben,\n• lösche, verschiebe und benenne Alben um,\n• bearbeiten, herunterladen und löschen von Fotos & Videos,\n• lege ein Foto als Albumbild fest,\n• Lade Fotos hoch:\n - veränderbare Größe und Qualität,\n - mit Beschreibung, Autor, Schlagwörtern, EXIF-Metadaten,\n - mit oder ohne GPS-Metadaten.\n• Videos hochladen.\n\nPiwigo ermöglicht, Deine eigene Fotogalerie im Web zu erstellen. Es beinhaltet viele leistungsstarke Funktionen wie Alben, Verschlagwortung, Geolocation, Vielfache individuelle Anpassungsmöglichkeiten, hochladen von Bildern durch Besucher, indem Besucher, Sicherheitsstufen, Kalender oder Statistiken.\n\nPiwigo ist kostenlos und Opensource.";
+
+"feedback" = "Feedback oder Fragen?\nPiwigo bietet kostenlosen Support über %@, wir würden uns freuen von Dir zu hören.";
+
+"promotional_text" = "Deine kostenlose Piwigo Cloud Foto-Bibliothek!";

--- a/piwigo/Resources/de.lproj/InfoPlist.strings
+++ b/piwigo/Resources/de.lproj/InfoPlist.strings
@@ -1,0 +1,9 @@
+/* 
+  InfoPlist.strings
+  piwigo
+
+  Created by Eddy Lelièvre-Berna on 13/08/2017.
+  Copyright © 2017 Piwigo.org. All rights reserved.
+*/
+
+"NSPhotoLibraryUsageDescription" = "so that it will be able to download images to Photos and upload images to your Piwigo.";

--- a/piwigo/Resources/de.lproj/Localizable.strings
+++ b/piwigo/Resources/de.lproj/Localizable.strings
@@ -1,0 +1,399 @@
+/*
+ Localizable.strings
+ piwigo
+ 
+ Created by Spencer Baker on 1/17/15.
+ Copyright (c) 2015 bakercrew. All rights reserved.
+ */
+// ===========================================================================
+// ==> GENERIC
+// ===========================================================================
+// Tab bar
+
+"tabBar_albums" = "Alben";
+"tabBar_upload" = "Hochladen";
+"tabBar_preferences" = "Einstellungen";
+
+// Alert buttons
+"alertOkButton" = "OK";
+"alertDismissButton" = "Verwerfen";
+"alertYesButton" = "Ja";
+"alertNoButton" = "Nein";
+"alertTryAgainButton" = "Erneut versuchen";
+"alertCancelButton" = "Abbrechen";
+"alertAddButton" = "Hinzufügen";
+"alertRetryButton" = "Erneut versuchen";
+"alertNextButton" = "Nächstes Bild";
+
+// Complete views
+"Complete" = "Abgeschlossen";
+
+// Upload rights
+"uploadRights_title" = "Erforderliche Rechte zum Hochladen benötigt";
+"uploadRights_message" = "Du benötigst Rechte zum Hochladen von Bildern oder Videos.";
+
+// Errors
+"internetErrorGeneral_title" = "Verbindungsfehler";
+"internetErrorGeneral_broken" = "Die Kommunikation wurde unterbrochen. Versuche Dich erneut anzumelden.";
+"internetCancellingConnection_button" = "Verbindung wird abgebrochen…";
+"internetCancelledConnection_button" = "Verbindung abbrechen";
+"internetCancelledConnection_title" = "Verbindung abgebrochen";
+
+// ===========================================================================
+// ==> LOGIN / LOGOUT
+// ===========================================================================
+// Login
+"login" = "Anmelden";
+"login_serverPlaceholder" = "Webadresse";
+"login_userPlaceholder" = "Benutzername (optional)";
+"login_passwordPlaceholder" = "Passwort (optional)";
+"login_loggingIn" = "Anmeldung läuft...";
+"login_protocolDescription" = "(Zum Ändern tippen)";
+"login_connecting" = "Verbinde";
+"login_newSession" = "Starte die Sitzung";
+"login_communityParameters" = "Community Parameter";
+"login_serverParameters" = "Piwigo Parameter";
+"login_connectionChanged" = "Verbindung geändert!";
+
+// Login — Errors
+"serverMethodsError_title" = "Unbekannte Methoden";
+"serverMethodsError_message" = "Fehler beim Abrufen der Servermethoden. Probleme mit dem Piwigo Server?";
+
+"loginError_title" = "Anmeldung Fehlgeschlagen";
+"loginError_message" = "Benutzername und Passwort stimmen für die angegebene Webadresse nicht überein";
+"loginEmptyServer_title" = "Webadresse eingeben";
+"loginEmptyServer_message" = "Bitte wählen Sie ein Protokoll und geben Sie eine Piwigo Webadresse ein, um fortfahren zu können.";
+
+"serverVersionNotCompatible_title" = "Serverinkompatibilität";
+"serverVersionNotCompatible_message" = "Deine Piwigo Serverversion ist %@. Piwigo Mobile unterstützt nur Versionen ab 2.7. Bitte aktualisiere Deinen Server um Piwigo Mobile verwenden zu können. Möchtest Du trotzdem fortfahren?";
+
+"sessionStatusError_title" = "Authentifizierung fehlgeschlagen";
+"sessionStatusError_message" = "Konnte den Server nicht authentifizieren. Versuche erneute Anmeldung.";
+
+"serverCommunityError_title" = "Kommunikationsfehler";
+"serverCommunityError_message" = "Konnte die Parameter der CommunityErweiterung nicht abrufen. Versuche erneute Anmeldung.";
+
+// Logout
+"logoutConfirmation_title" = "Abmelden";
+"logoutConfirmation_message" = "Willst Du Dich wirklich abmelden?";
+
+// Logout — Errors
+"logoutFail_title" = "Abmelden fehlgeschlagen";
+"logoutFail_message" = "Abmelden fehlgeschlagen. Nochmals versuchen?";
+
+
+// ===========================================================================
+// ==> ALBUMS
+// ===========================================================================
+// Albums view
+"categoryMainEmtpy" = "Bislang keine Alben in Deinem Piwigo enthalten. Du kannst zur Aktualisierung nach unten ziehen oder Dich erneut anmelden.";
+"categoryTableView_photoCount" = "Foto";
+"categoryTableView_photosCount" = "Fotos";
+"categoryTableView_subCategoryCount" = "Unter-Album";
+"categoryTableView_subCategoriesCount" = "Unter-Alben";
+"categoryImageList_selectButton" = "Wählen";
+"categoryImageList_noDataError" = "Fehler keine Daten";
+
+// Albums sort
+"categorySort_nameAscending" = "Fototitel, A → Z";
+"categorySort_nameDescending" = "Fototitel, Z → A";
+"categorySort_fileNameAscending" = "Dateiname, A → Z";
+"categorySort_fileNameDescending" = "Dateiname, Z → A";
+"categorySort_dateCreatedDescending" = "Erstelldatum, Neu → Alt";
+"categorySort_dateCreatedAscending" = "Erstelldatum, Alt → Neu";
+"categorySort_datePostedDescending" = "Veröffentlichung, Neu → Alt";
+"categorySort_datePostedAscending" = "Veröffentlichung, Alt → Neu";
+"categorySort_videosOnly" = "Nur Videos";
+"categorySort_imagesOnly" = "Nur Bilder";
+
+// Album create
+"createNewAlbum_title" = "Neues Album";
+"createNewAlbum_message" = "Gib einen Namen für dieses Album ein.";
+"createNewAlbum_placeholder" = "Albumname";
+"createNewAlbumHUD_label" = "Erstelle Album…";
+
+// Album create — Errors
+"createAlbumError_title" = "Fehler: Album erstellen";
+"createAlbumError_message" = "Erstellen eines neuen Albums fehlgeschlagen";
+
+// Album options (actions)
+"categoryCellOption_rename" = "Umbenennen";
+"categoryCellOption_move" = "Verschieben";
+"categoryCellOption_delete" = "Löschen";
+
+// Album rename
+"renameCategory_title" = "Album Umbenennen";
+"renameCategory_message" = "Gib einen neuen Namen für dieses Album ein";
+"renameCategory_button" = "Umbenennen";
+"renameCategoryHUD_label" = "Album wird umbenannt…";
+
+// Album rename — Errors
+"renameCategoyError_title" = "Umbenennung fehlgeschlagen";
+"renameCategoyError_message" = "Umbenennung Deines Albums fehlgeschlagen";
+
+// Album delete
+"deleteCategory_title" = "ALBUM LÖSCHEN";
+"deleteCategory_message" = "BIST DU SICHER, DASS DU DAS ALBUM \"%@\" UND DESSEN %@ BILDER LÖSCHEN MÖCHTEST?";
+"deleteCategoryConfirm_title" = "Bist du sicher?";
+"deleteCategoryConfirm_message" = "Gib bitte die Anzahl der Bilder an um dieses Album zu löschen.\nAnzahl der Bilder: %@";
+"deleteCategoryConfirm_deleteButton" = "LÖSCHEN";
+"deleteCategoryHUD_label" = "Album wird gelöscht…";
+
+// Album delete — errors
+"deleteCategoryMatchError_title" = "Anzahl stimmt nicht überein";
+"deleteCategoryMatchError_message" = "Die Anzahl der Bilder, die Du eingegeben hast, entspricht nicht der Anzahl der Bilder im Album. Bitte versuche es erneut, wenn Du dieses Album löschen möchtest";
+"deleteCategoryError_title" = "Löschen fehlgeschlagen";
+"deleteCategoryError_message" = "Fehler beim Löschen Deines Albums";
+
+// Album move
+"moveCategory" = "Album verschieben";
+"moveCategory_selectParent" = "Wähle ein Album aus, in das Du das Album \"%@\" verschieben möchtest";
+"moveCategory_message" = "Möchtest Du wirklich das Album \"%@\" in das Album \"%@\" verschieben?";
+"moveCategoryHUD_moving" = "Album wird verschoben…";
+
+// album move — Errors
+"moveCategoryError_title" = "Verschieben fehlgeschlagen";
+"moveCategoryError_message" = "Fehler beim Verschieben Deines Albums";
+
+// Album set image thumbnail
+"categorySelection" = "Album auswählen";
+"categorySelection_forImage" = "Wähle ein Album für dieses Bild";
+"categoryImageSet_title" = "Miniaturbild setzen";
+"categoryImageSet_message" = "Möchtest Du wirklich dieses Miniaturbild für das Album \"%@\" festlegen?";
+"categoryImageSetHUD_updating" = "Album Miniaturbild wird aktualisiert…";
+
+// Album set image thumbnail — Errors
+"categoryImageSetError_title" = "Fehler beim setzen des Miniaturbild";
+"categoryImageSetError_message" = "Setzen des Miniaturbild für das Album fehlgeschlagen";
+
+
+// ===========================================================================
+// ==> IMAGES
+// ===========================================================================
+"noImages" = "Keine Bilder";
+"pullToRefresh" = "Bilder erneut laden";
+
+// Errors
+"albumPhotoError_title" = "Bildfehler im Album";
+"albumPhotoError_message" = "Beim Abrufen der Fotos im Album ist ein Fehler aufgetreten (fehlerhafte Bilddateien in Deinem Album?)";
+
+// Image sort
+"sortTitle" = "Sortierung";
+"sortBy" = "Sortieren nach";
+
+// Image options (actions)
+"imageOptions_title" = "Bildoptionen";
+"imageOptions_edit" = "Bearbeiten";
+"imageOptions_download" = "Runterladen";
+"imageOptions_setAlbumImage" = "Als Album-Titelbild festlegen";
+
+// Image details
+"imageDetailsView_title" = "Bildinformationen";
+"editImageDetails_title" = "Titel:";
+"editImageDetails_titlePlaceholder" = "Titel";
+"editImageDetails_author" = "Autor:";
+"editImageDetails_tags" = "Schlagwörter:";
+"editImageDetails_privacyLevel" = "Wer darf dieses Foto sehen?";
+"editImageDetails_descriptionPlaceholder" = "Beschreibung";
+"editImageDetailsHUD_updating" = "Bildinformationen werden aktualisiert…";
+
+// Image details — Errors
+"editImageDetailsError_title" = "Fehler bei der Aktualisierung";
+"editImageDetailsError_message" = "Übertragen der Änderungen auf Deinen Server fehlgeschlagen.\nErneut versuchen?";
+"imageDetailsFetchError_title" = "Abrufen der Bilddetails fehlgeschlagen";
+"imageDetailsFetchError_retryMessage" = "Abrufen der Bildinformationen fehlgeschlagen.\nErneut versuchen?";
+"imageDetailsFetchError_continueMessage" = "Abrufen der Bildinformationen fehlgeschlagen.\nFortsetzen?";
+
+// Image privacy levels
+"privacyLevel" = "Sicherheitsstufe";
+"privacyLevel_admin" = "Admins";
+"privacyLevel_adminFamily" = "Admins, Familie";
+"privacyLevel_adminsFamilyFriends" = "Admins, Familie, Freunde";
+"privacyLevel_adminsFamilyFriendsContacts" = "Admins, Familie, Freunde, Kontakte";
+"privacyLevel_everybody" = "Jeder";
+
+// Image tags
+"none" = "keine";
+"tags" = "Schlagwörter";
+"tagsHeader_selected" = "Ausgewählt";
+"tagsHeader_all" = "Alle";
+
+// Image delete
+"deleteImage_delete" = "Löschen";
+"deleteImage_imagePlural" = "Bilder";
+"deleteImageProgress_title" = "Löschen von %@%% erledigt";
+
+"deleteSingleImage_title" = "Bild löschen";
+"deleteSingleImage_message" = "Möchtest Du dieses Bild wirklich löschen? Dies kann nicht rückgängig gemacht werden!";
+"deleteSeveralImages_title" = "Bilder löschen";
+"deleteSeveralImages_message" = "Möchtest Du die %@ ausgewählten Bilder wirklich löschen? Dies kann nicht rückgängig gemacht werden!";
+
+"deleteImageFail_title" = "Löschen fehlgeschlagen";
+"deleteImageFail_message" = "Bilder konnten nicht gelöscht werden\n%@";
+
+// Image download
+"downloadSingleImage_title" = "Bild herunterladen";
+"downloadSingleImage_confirmation" = "Möchtest Du wirklich die markierten Bilder herunterladen?";
+"downloadSeveralImages_title" = "Bilder herunterladen";
+"downloadSeveralImage_confirmation" = "Möchtest Du wirklich die %@ markierten Bilder herunterladen?";
+
+"downloadingImage" = "Bild herunterladen";
+"downloadingImages" = "Bilder herunterladen";
+"downloadingImageInfo" = "Bildinformationen herunterladen";
+"downloadingImageInfoForSort" = "Bildinformationen für Sortierung herunterladen";
+
+// Image download — Errors
+"downloadImageFail_title" = "Herunterladen fehlgeschlagen";
+"downloadImageFail_message" = "Bild herunterladen fehlgeschlagen!\n%@";
+"downloadVideoFail_message" = "Video herunterladen fehlgeschlagen!\n%@";
+"downloadVideoFail_Photos" = "Videoformate werden von Fotos nicht unterstützt!";
+
+"imageSaveError_title" = "Bild speichern fehlgeschlagen";
+"imageSaveError_message" = "Bild speichern fehlgeschlagen. Fehler: %@";
+
+"videoSaveError_title" = "Video speichern fehlgeschlagen";
+"videoSaveError_message" = "Video speichern fehlgeschlagen. Fehler: %@";
+
+// Images upload
+"categoryUpload_chooseAlbum" = "Wähle ein Album zum Hochladen der Bilder";
+"categoryUpload_chooseLocalAlbum" = "Wähle ein Album um Bilder zu erhalten";
+"categoyUpload_loadSubCategories" = "Laden";
+"selectAll" = "Alle";
+
+"imageUploadDetails_title" = "Titel:";
+"imageUploadDetails_author" = "Autor:";
+"imageUploadDetails_privacy" = "Sicherheitsstufe:";
+"imageUploadDetails_tags" = "Schlagwörter:";
+"imageUploadDetails_description" = "Beschreibung:";
+
+"imageUploadDetailsView_title" = "Bilder";
+"imageUploadDetailsButton_title" = "Hochladen";
+"imageUploadDetailsEdit_title" = "Bearbeite Bilder zum Hochladen";
+"imageUploadDetailsUploading_title" = "Bilder, die hochgeladen werden";
+"imageUploadDetailsCell_uploadComplete" = "Fertig! Abschliessen ...";
+
+"imageUploadTableCell_uploading" = "Wird hochgeladen ...";
+"imageUploadProgressBar_zero" = "Hochladen 0/0";
+"imageUploadProgressBar_nonZero" = "Hochladen %@/%@";
+"imageUploadProgressBar_completed" = "Abgeschlossen";
+"imageUploadCompleted_title" = "Erfolgreich hochgeladen";
+"imageUploadCompleted_message" = "Bilder/Videos wurden auf Deinen Piwigo-Server hochgeladen.";
+"imageUploadCompleted_message>1" = "Bilder/Videos auf Deinen Piwigo-Server hochgeladen.";
+
+// Image upload — Errors
+"uploadError_title" = "Fehler beim Hochladen";
+"uploadError_message" = "Konnte Dein Bild nicht hochladen. Fehler: %@";
+"videoUploadError_title" = "Fehler beim Video Hochladen";
+"videoUploadError_message" = "Du musst Deinem Piwigo-Server die Erweiterung \"VideoJS\" hinzufügen, Deine lokale Konfigurationsdatei bearbeiten und das Hochladen von Videos erlauben.";
+"videoUploadConfigError_message" = "Bitte überprüfe die Installation der \"VideoJS\" Erweiterung und deren Konfigurationsdatei mit dem LocalFiles-Editor, um das Hochladen von Videos auf Deinen Piwigo-Server zu erlauben.";
+"videoUploadError_format" = "Das Video-Dateiformat ist nicht mit der \"VideoJS\" Erweiterung kompatibel.";
+
+
+// ===========================================================================
+// ==> LOCAL ALBUMS
+// ===========================================================================
+"localAlbums" = "Lokale Alben";
+
+"localImageSort_newest" = "Neueste";
+"localImageSort_oldest" = "Älteste";
+"localImageSort_notUploaded" = "Nicht hochgeladen";
+"localImageSort_undefined" = "Undefiniert";
+
+// Local albums — Access not Authorized
+"localAlbums_photosNotAuthorized_title" = "Kein Zugriff";
+"localAlbums_photosNiltitle" = "Problem beim Lesen der Fotos";
+"localAlbums_photosNnil_msg" = "Es gibt ein Problem beim Lesen der lokalen Foto Bibliothek.";
+
+// Local albums — Tell user to change settings, how
+"localAlbums_photosNotAuthorized_msg" = "Konnte die lokale Foto Bibliothek nicht öffnen.\nBitte gehe in die Einstellungen, Privatsphäre, Fotos und ermögliche den Zugriff für Piwigo-Mobile.";
+
+// ===========================================================================
+// ==> SETTINGS
+// ===========================================================================
+// Settings — Piwigo Server
+"settingsHeader_server" = "Piwigo Server";
+"settings_server" = "Webadresse";
+"settings_username" = "Benutzername";
+"settings_notLoggedIn" = " -Nicht eingeloggt- ";
+"settings_logout" = "Abmelden";
+
+// Settings — General
+"settingsHeader_general" = "Allgemeine Einstellungen";
+"settings_loadAllCategories" = "Alle Alben beim Start herunterladen";
+"settings_loadAllCategories>320px" = "Alle Alben beim Start herunterladen (bei Problemen deaktivieren)";
+"defaultImageSort" = "Sortierung";
+"defaultImageSort>320px" = "Standardsortierung";
+"defaultImageSort>414px" = "Standardsortierung der Bilder";
+
+"defaultThumbnailSize" = "Miniaturbilder";
+"defaultThumbnailSize>320px" = "Miniaturbildergröße";
+"defaultThumbnailSize>414px" = "Standardgröße der Miniaturbilder";
+"defaultThumbnailSizeTitle" = "Standardgröße";
+"defaultThumbnailSizeHeader" = "Bitte wähle eine Miniaturbildgröße";
+"defaultThumbnailSize_disabled" = " (auf Server deaktiviert)";
+"settings_displayTitles" = "Titel bei Miniaturbildern";
+"settings_displayTitles>320px" = "Titel bei Miniaturbildern anzeigen";
+
+"thumbnailSizeSquare" = "Quadratisch (schneller)";
+"thumbnailSizeThumbnail" = "Miniaturbilder (Standard)";
+"thumbnailSizeXXSmall" = "Mini (besser)";
+"thumbnailSizeXSmall" = "Extra klein";
+"thumbnailSizeSmall" = "Klein";
+"thumbnailSizeMedium" = "Mittel";
+"thumbnailSizeLarge" = "Groß";
+"thumbnailSizeXLarge" = "Extra Groß";
+"thumbnailSizeXXLarge" = "Riesig";
+"thumbnailSizexFullRes" = "Volle Auflösung";
+
+"defaultImageSize" = "Bilder";
+"defaultImageSize>320px" = "Bildergröße";
+"defaultImageSize>414px" = "Standardgröße der Bilder";
+"defaultImageSizeTitle" = "Standardgröße";
+"defaultImageSizeHeader" = "Bitte wähle eine Bildgröße";
+"defaultImageSize_recommended" = " (empfohlen)";
+"defaultImageSize_disabled" = " (auf Server deaktiviert)";
+
+"imageSizeSquare" = "Quadratisch";
+"imageSizeThumbnail" = "Miniaturbild";
+"imageSizeXXSmall" = "Mini";
+"imageSizeXSmall" = "Extra klein";
+"imageSizeSmall" = "Klein";
+"imageSizeMedium" = "Mittel";
+"imageSizeLarge" = "Groß";
+"imageSizeXLarge" = "Extra Groß";
+"imageSizeXXLarge" = "Riesig";
+"imageSizexFullRes" = "Volle Auflösung";
+
+// Settings — Upload
+"settingsHeader_upload" = "Standard-Upload-Einstellungen";
+"settings_defaultAuthor" = "Autor";
+"settings_defaultAuthor>320px" = "Autorname";
+"settings_defaultAuthorPlaceholder" = "Autorname";
+"settings_defaultPrivacy" = "Sicherheitsstufe";
+"settings_defaultPrivacy>414px" = "Wer darf die Medien sehen?";
+"settings_stripGPSdata" = "GPS Metadaten löschen";
+"settings_stripGPSdata>375px" = "GPS Metadaten vor dem Hochladen löschen";
+"settings_photoResize" = "Vor dem Hochladen Größe anpassen";
+"settings_photoResize>375px" = "Bildgröße vor dem Hochladen anpassen";
+"settings_photoSize" = "> Größe   ";
+"settings_placeholderSize" = "Gib eine Fotogröße von 1-100 an";
+"settings_photoQuality" = "> Qualität";
+"settings_placeholderQuality" = "Gib eine Bildqualität von 50-98 an";
+
+// Settings — Cache
+"settingsHeader_cache" = "Cache-Einstellungen (Verwendet/Total)";
+"settings_cacheDisk" = "Datenträger";
+"settings_placeholderDisk" = "Gib einen Disk-Cache von 10-200 an";
+"settings_cacheMemory" = "Speicher";
+"settings_placeholderMemory" = "Gib einen Speicher-Cache von 10-200 an";
+"settings_cacheMegabytes" = "MB";
+
+// Settings — Information
+"settings_appName" = "Piwigo Mobile";
+"settingsHeader_about" = "Informationen";
+"settings_supportForum" = "Support-Forum";
+"settings_releaseNotes" = "Versionshinweise";
+"settings_rateInAppStore" = "Piwigo Mobile bewerten";
+"settings_translateWithCrowdin" = "Piwigo Mobile übersetzen";
+"settings_pwgForumURL" = "http://de.piwigo.org/forum/";
+"settings_acknowledgements" = "Danksagungen";

--- a/piwigo/Resources/de.lproj/ReleaseNotes.strings
+++ b/piwigo/Resources/de.lproj/ReleaseNotes.strings
@@ -1,0 +1,27 @@
+/*
+ ReleaseNotes.strings
+ piwigo
+ 
+ Created by Eddy Lelièvre-Berna on 15/07/2017.
+ Copyright © 2017 Piwigo.org. All rights reserved.
+ */
+
+"v2.1.3_text" = "Version 2.1.3\n • Hinzugefügt Basiszugriffsauthentifizierung\n • Möglichkeit die automatische Verbindung abzubrechen\n • Verbesserung der Schnittstelle und Verwaltung beim Hochladen\n • Aktualisierte Übersetzungen und iOS 11 Kompatibilität\n • Fehlerbehebung beim \"Nicht hochgeladen\" Filter\n • Code Aktualisierung\n________________________________________\n\n";
+
+"v2.1.2_text" = "Version 2.1.2\n7. September 2017\n\n• Fehlerbehebung Anmeldung verweigert in Zusammenhang mit der Community Erweiterung Versionen < 2.9 \n• Aktualisierte Übersetzungen \n• Hausputz\n________________________________________  \n\n";
+
+"v2.1.1_text" = "Version 2.1.1\n20. August 2017\n\n• Fehlerbehebung ungültigen SSL-Zertifikaten\n• Aktualisierte dänische Übersetzung\n________________________________________\n\n";
+
+"v2.1.0_text" = "Version 2.1\n14. August 2017\n\n• Kompatibilität mit der Community Erweiterung\n• Dänische, Französische, Polnische Übersetzungen\n• Fehlerbehebungen\n________________________________________\n\n";
+
+"v2.0.4_text" = "Version 2.0.4\n28. Juli 2017\n\n• iPad - Fehlerbeseitigung für unscharfe Miniaturen und der fehlenden Bearbeitungsmöglichkeit von Fotos\n• Videos - Fehlerbehebung mein Hoch- und Herunterladen (VideoJS Erweiterung auf dem Piwigo Server erforderlich)\n• Einstellungen - Optionen hinzugefügt um Titel zu entfernen und die Auflösung von Miniaturbildern verändern zu können\n• Verbessert - Zuverlässigkeit bei der Serververbindung, Meldung wenn das Hochladen abgeschlossen wurde\n• kleinere Fehler beseitigt und Verbesserungen der Benutzeroberfläche\n________________________________________\n\n";
+
+"v2.0.3_text" = "Version 2.0.3\nMai 26, 2017\n\n• Option in den Einstellungen hinzugefügt um GPS-Metadaten zu löschen\n• Cache-Nutzung in den Einstellungen ersichtlich\n• Fehlerbehebung Cache Einstellungen wurden manchmal gelöscht/Reset\n• Fehlerbehebung Bild hochladen Einstellungen wurden manchmal gelöscht/Reset\n________________________________________\n\n";
+
+"v2.0.2_text" = "Version 2.0.2\n8. Mai 2017\n\n• Sortierkriterien sind jetzt identisch zur Piwigo Web App\n• Fehlerbehebung von Sortierungsfehlern\n• Fehlerbehebung Absturz beim Hinzufügen von Schlagwörtern zu einem Foto vor dem Hochladen\n• Fehlerbehebung für Situationen bei denen das Löschen ausgewählter Bilder nicht funktionierte\n• Fehlerbehebung für Situationen bei denen ein Album nach dem Verschieben nicht angezeigt wurde\n• Fehlerbehebung von Kompatibilitätsproblem mit iOS 10 — veralteter Code\n________________________________________\n\n";
+
+"v2.0.1_text" = "Version 2.0.1\n26. Juni 2015\n\nNeue Einstellungen:\n- Option, um die Größe von Bildern während des Hochladens zu ändern\n + Bildqualität zwischen 50-98% wählbar\n- Möglichkeit um eine Standard Miniaturbildgröße festzulegen\nFehlerbehebungen\n________________________________________\n\n";
+
+"v2.0.0_text" = "Version 2.0\n24. April 2015\n\nNeue native App mit den Funktionen:\n- Alben - Verwaltung\n- Bilder ansehen\n- Hochladen von mehreren Bildern\n- Video hochladen und Wiedergabe (VideoJS Erweiterung muss auf dem Piwigo-Server installiert sein)\n________________________________________\n\n";
+
+"v1.0.0_text" = "Version 1.0\n17. Oktober 2011";

--- a/piwigo/Resources/fr.lproj/About.strings
+++ b/piwigo/Resources/fr.lproj/About.strings
@@ -10,7 +10,7 @@
 "authors2" = "et Eddy Lelièvre-Berna";
 "version" = "Version :";
 
-"translators_text" = "Nous remercions sincèrement pour leur temps et les efforts concédés pour traduire Piwigo: Thomas Christfort (Danois), Robert Mulder (Hollandais), Michał Majchrowicz (Polonais).\n\n";
+"translators_text" = "Nous remercions sincèrement pour leur temps et les efforts concédés pour traduire Piwigo: Thomas Christfort (Danois), Jörg Knoerchen (Allemand), Robert Mulder (Hollandais), Michał Majchrowicz (Polonais).\n\n";
 
 "about_text" = "Ce logiciel contient certains logiciels tiers qui sont redistribués selon les modalités et les conditions de leurs licences originales.\n\n";
 

--- a/piwigo/Resources/fr.lproj/Localizable.strings
+++ b/piwigo/Resources/fr.lproj/Localizable.strings
@@ -23,7 +23,7 @@
 "alertCancelButton" = "Annuler";
 "alertAddButton" = "Ajouter";
 "alertRetryButton" = "Réessayer";
-"alertNextButton" = "Image suivante";
+"alertNextButton" = "Image Suivante";
 
 // Complete views
 "Complete" = "Terminé";
@@ -35,7 +35,7 @@
 // Errors
 "internetErrorGeneral_title" = "Erreur de Connexion";
 "internetErrorGeneral_broken" = "Désolé, la communication a été interrompue. Essayez de vous connecter à nouveau.";
-"internetCancellingConnection_button" = "Annulation de la connexion…";
+"internetCancellingConnection_button" = "Annulation de la Connexion…";
 "internetCancelledConnection_button" = "Annuler la Connexion";
 "internetCancelledConnection_title" = "Connexion Annulée";
 
@@ -50,7 +50,7 @@
 "login_loggingIn" = "Connexion en cours...";
 "login_protocolDescription" = "(taper > changer)";
 "login_connecting" = "Connexion en cours";
-"login_newSession" = "Ouverture de la Connexion";
+"login_newSession" = "Ouverture de la Session";
 "login_communityParameters" = "Paramètres Community";
 "login_serverParameters" = "Paramètres Piwigo";
 "login_connectionChanged" = "Connexion Modifiée !";
@@ -107,10 +107,10 @@
 "categorySort_imagesOnly" = "Images Uniquement";
 
 // Album create
-"createNewAlbum_title" = "Nouvel album";
+"createNewAlbum_title" = "Nouvel Album";
 "createNewAlbum_message" = "Entrez un nom pour cet album.";
 "createNewAlbum_placeholder" = "Nom de l’Album";
-"createNewAlbumHUD_label" = "Création en cours…";
+"createNewAlbumHUD_label" = "Création de l'Album…";
 
 // Album create — Errors
 "createAlbumError_title" = "Echec de la Création d'Album";
@@ -125,7 +125,7 @@
 "renameCategory_title" = "Renommer l'Album";
 "renameCategory_message" = "Entrez un nouveau nom pour cet album";
 "renameCategory_button" = "Renommer";
-"renameCategoryHUD_label" = "Changement de nom en cours…";
+"renameCategoryHUD_label" = "Changement du Nom…";
 
 // Album rename — Errors
 "renameCategoyError_title" = "Echec du Changement";
@@ -137,7 +137,7 @@
 "deleteCategoryConfirm_title" = "Etes-vous sûr ?";
 "deleteCategoryConfirm_message" = "Veuillez entrer le nombre d’images afin de supprimer cet album.\nNombre d’images : %@";
 "deleteCategoryConfirm_deleteButton" = "SUPPRIMER";
-"deleteCategoryHUD_label" = "Suppression en cours…";
+"deleteCategoryHUD_label" = "Suppression de l'Album…";
 
 // Album delete — errors
 "deleteCategoryMatchError_title" = "Nombre Incorrect";
@@ -149,7 +149,7 @@
 "moveCategory" = "Déplacer l'Album";
 "moveCategory_selectParent" = "Sélectionnez un album pour déplacer l’album \"%@\" dans";
 "moveCategory_message" = "Êtes-vous certain de vouloir déplacer \"%@\" dans l’album \"%@\" ?";
-"moveCategoryHUD_moving" = "Déplacement en cours…";
+"moveCategoryHUD_moving" = "Déplacement de l'Album…";
 
 // album move — Errors
 "moveCategoryError_title" = "Echec";
@@ -160,7 +160,7 @@
 "categorySelection_forImage" = "Sélectionnez un album pour cette image";
 "categoryImageSet_title" = "Affecter une Vignette";
 "categoryImageSet_message" = "Êtes-vous certain de vouloir affecter cette image à l’album \"%@\" ?";
-"categoryImageSetHUD_updating" = "Modification de la vignette…";
+"categoryImageSetHUD_updating" = "Modification de la Vignette…";
 
 // Album set image thumbnail — Errors
 "categoryImageSetError_title" = "Echec d'Affectation";
@@ -201,7 +201,7 @@
 "editImageDetailsError_title" = "Échec de la Modification";
 "editImageDetailsError_message" = "Echec de l'enregistrement des modifications sur votre serveur. Réessayez ?";
 "imageDetailsFetchError_title" = "Echec Récupération Détails";
-"imageDetailsFetchError_retryMessage" = "La récupération des données de l’image a échoué.\nEssayer à nouveau ?";
+"imageDetailsFetchError_retryMessage" = "La récupération des données de l’image a échoué.\nRéessayer ?";
 "imageDetailsFetchError_continueMessage" = "La récupération des données de l’image a échoué.\nContinuer ?";
 
 // Image privacy levels

--- a/piwigo/Resources/pl.lproj/About.strings
+++ b/piwigo/Resources/pl.lproj/About.strings
@@ -10,7 +10,7 @@
 "authors2" = "i Eddy Lelièvre-Berna";
 "version" = "Wersja:";
 
-"translators_text" = "Chcielibyśmy serdecznie podziękować następującym użytkownikom za swój czas i wysiłek włożony w tłumaczenie Piwigo: Thomas Christfort (duński), Robert Mulder (holenderski), Michał Majchrowicz (polski).\n\n";
+"translators_text" = "Chcielibyśmy serdecznie podziękować następującym użytkownikom za swój czas i wysiłek włożony w tłumaczenie Piwigo: Thomas Christfort (duński), Jörg Knoerchen (niemiecki), Robert Mulder (holenderski), Michał Majchrowicz (polski).\n\n";
 
 "about_text" = "To oprogramowanie zawiera niektóre oprogramowania innych firm, które są rozprowadzane na zasadach i warunkach ich oryginalnej licencji.\n\n";
 

--- a/piwigo/Resources/pl.lproj/Localizable.strings
+++ b/piwigo/Resources/pl.lproj/Localizable.strings
@@ -22,8 +22,8 @@
 "alertTryAgainButton" = "Spróbuj jeszcze raz";
 "alertCancelButton" = "Anuluj";
 "alertAddButton" = "Dodaj";
-"alertRetryButton" = "Retry";
-"alertNextButton" = "Next Image";
+"alertRetryButton" = "Ponów";
+"alertNextButton" = "Następne zdjęcie";
 
 // Complete views
 "Complete" = "Zakończono";
@@ -35,9 +35,9 @@
 // Errors
 "internetErrorGeneral_title" = "Błąd połączenia";
 "internetErrorGeneral_broken" = "Przepraszamy komunikacja została przerwana. \nSpróbuj zalogować się ponownie.";
-"internetCancellingConnection_button" = "Cancelling Connection…";
+"internetCancellingConnection_button" = "Anulowanie połączenia…";
 "internetCancelledConnection_button" = "Połączenie Anulowane";
-"internetCancelledConnection_title" = "Connection Cancelled";
+"internetCancelledConnection_title" = "Połączenie anulowane";
 
 // ===========================================================================
 // ==> LOGIN / LOGOUT
@@ -49,8 +49,8 @@
 "login_passwordPlaceholder" = "Hasło (opcjonalne)";
 "login_loggingIn" = "Logowanie...";
 "login_protocolDescription" = "(dotknij by zmienić)";
-"login_connecting" = "Connecting";
-"login_newSession" = "Opening Session";
+"login_connecting" = "Łączenie";
+"login_newSession" = "Otwieranie sesji";
 "login_communityParameters" = "Community parametrów";
 "login_serverParameters" = "Piwigo parametrów";
 "login_connectionChanged" = "Połączenie uległo zmianie!";
@@ -108,9 +108,9 @@
 
 // Album create
 "createNewAlbum_title" = "Nowy Album";
-"createNewAlbum_message" = "Enter a name for this album.";
+"createNewAlbum_message" = "Wprowadź nazwę albumu.";
 "createNewAlbum_placeholder" = "Nazwa Albumu";
-"createNewAlbumHUD_label" = "Creating Album…";
+"createNewAlbumHUD_label" = "Tworzenie albumu…";
 
 // Album create — Errors
 "createAlbumError_title" = "Błąd Tworzenia Albumu";
@@ -123,9 +123,9 @@
 
 // Album rename
 "renameCategory_title" = "Zmień Nazwę Albumu";
-"renameCategory_message" = "Enter a new name for this album";
+"renameCategory_message" = "Wprowadź nową nazwę dla tego albumu";
 "renameCategory_button" = "Zmień Nazwę";
-"renameCategoryHUD_label" = "Renaming Album…";
+"renameCategoryHUD_label" = "Zmiana nazwy albumu…";
 
 // Album rename — Errors
 "renameCategoyError_title" = "Błąd Zmiany Nazwy";
@@ -137,7 +137,7 @@
 "deleteCategoryConfirm_title" = "Czy na pewno?";
 "deleteCategoryConfirm_message" = "Proszę wpisać liczbę zdjęć w celu usunięcia tego albumu.\nLiczba zdjęć: %@";
 "deleteCategoryConfirm_deleteButton" = "USUŃ";
-"deleteCategoryHUD_label" = "Deleting Album…";
+"deleteCategoryHUD_label" = "Usuwanie albumu…";
 
 // Album delete — errors
 "deleteCategoryMatchError_title" = "Numer nie jest zgodny";
@@ -149,7 +149,7 @@
 "moveCategory" = "Przenieść Album";
 "moveCategory_selectParent" = "Wybierz album, do którego chcesz przenieść album \"%@\"";
 "moveCategory_message" = "Czy na pewno chcesz przenieść \"%@\" do albumu \"%@\"?";
-"moveCategoryHUD_moving" = "Moving Album…";
+"moveCategoryHUD_moving" = "Przenoszenie albumu…";
 
 // album move — Errors
 "moveCategoryError_title" = "Błąd Przenoszenia";
@@ -160,7 +160,7 @@
 "categorySelection_forImage" = "Wybierz album dla tego zdjęcia";
 "categoryImageSet_title" = "Ustaw Miniaturę Zdjęcia";
 "categoryImageSet_message" = "Czy na pewno chcesz ustawić to zdjęcie dla albumu \"%@\"?";
-"categoryImageSetHUD_updating" = "Updating Album Thumbnail…";
+"categoryImageSetHUD_updating" = "Aktualizowanie miniatury albumu…";
 
 // Album set image thumbnail — Errors
 "categoryImageSetError_title" = "Błąd ustawiania zdjęcia";
@@ -195,14 +195,14 @@
 "editImageDetails_tags" = "Tagi:";
 "editImageDetails_privacyLevel" = "Kto może zobaczyć to zdjęcie?";
 "editImageDetails_descriptionPlaceholder" = "Opis";
-"editImageDetailsHUD_updating" = "Updating Image Info…";
+"editImageDetailsHUD_updating" = "Aktualizacja informacji obrazu…";
 
 // Image details — Errors
-"editImageDetailsError_title" = "Failed to Update";
-"editImageDetailsError_message" = "Failed to update your changes with your server.\nTry again?";
+"editImageDetailsError_title" = "Aktualizacja nieudana";
+"editImageDetailsError_message" = "Nie można zaktualizować zmian na serwerze. Spróbować ponownie?";
 "imageDetailsFetchError_title" = "Pobrania szczegółów zdjęcia nie powiodło się";
-"imageDetailsFetchError_retryMessage" = "Fetching the image data failed.\nTry again?";
-"imageDetailsFetchError_continueMessage" = "Fetching the image data failed.\nContinue?";
+"imageDetailsFetchError_retryMessage" = "Pobieranie danych zdjęcia nie powiodło się.\nSpróbować jeszcze raz?";
+"imageDetailsFetchError_continueMessage" = "Pobieranie danych zdjęcia nie powiodło się.\nKontynuować?";
 
 // Image privacy levels
 "privacyLevel" = "Poziom Prywatności";
@@ -275,7 +275,7 @@
 "imageUploadTableCell_uploading" = "Przesyłanie...";
 "imageUploadProgressBar_zero" = "Przesyłanie 0/0";
 "imageUploadProgressBar_nonZero" = "Przesyłanie %@/%@";
-"imageUploadProgressBar_completed" = "Completed";
+"imageUploadProgressBar_completed" = "Zakończono";
 "imageUploadCompleted_title" = "Przesyłanie Zakończone";
 "imageUploadCompleted_message" = "zdjęcie/wideo zostało przesłane do Twojego serwera Piwigo.";
 "imageUploadCompleted_message>1" = "zdjęcia/filmy zostały przesłane do Twojego serwera Piwigo.";

--- a/piwigo/Resources/pl.lproj/ReleaseNotes.strings
+++ b/piwigo/Resources/pl.lproj/ReleaseNotes.strings
@@ -6,7 +6,7 @@
  Copyright © 2017 Piwigo.org. All rights reserved.
  */
 
-"v2.1.3_text" = "Version 2.1.3\n\n• Add basic access authentication\n• Allow cancelling auto-connection\n• Improve interface and upload management\n• Improve translations and iOS 11 compatibility\n• Fix bug encountered with \"Not uploaded\" filter\n• Code modernization\n________________________________________\n\n";
+"v2.1.3_text" = "Wersja 2.1.3\n\n• Dodanie obsługi podstawowej autentykacji HTTP \n• Dodanie możliwości anulowania auto podłączania\n• Poprawki interfejsu i wysyłania\n• Poprawki tłumaczenia i obsługi iOS 11\n• Poprawki kodu\n\n________________________________________\n\n";
 
 "v2.1.2_text" = "Wersja 2.1.2\n7 września 2017\n\n• Poprawka odmowy logowania z wtyczką społeczność w wersji wtyczki < 2.9 \n• Poprawy tłumaczenia \n• Drobne poprawki\n________________________________________\n\n";
 

--- a/piwigo/Upload/Edit Image Details/EditImageDetailsViewController.m
+++ b/piwigo/Upload/Edit Image Details/EditImageDetailsViewController.m
@@ -188,11 +188,16 @@ typedef enum {
     // Change the background view shape, style and color.
     hud.square = NO;
     hud.animationType = MBProgressHUDAnimationFade;
-    hud.contentColor = [UIColor piwigoWhiteCream];
-    hud.bezelView.color = [UIColor colorWithWhite:0.f alpha:1.0];
     hud.backgroundView.style = MBProgressHUDBackgroundStyleSolidColor;
     hud.backgroundView.color = [UIColor colorWithWhite:0.f alpha:0.5f];
-    
+    if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_9_x_Max) {
+        hud.contentColor = [UIColor piwigoWhiteCream];
+        hud.bezelView.color = [UIColor colorWithWhite:0.f alpha:1.0];
+    } else {
+        hud.contentColor = [UIColor piwigoGray];
+        hud.bezelView.color = [UIColor piwigoGrayLight];
+    }
+
     // Define the text
     hud.label.text = NSLocalizedString(@"editImageDetailsHUD_updating", @"Updating Image Info…");
     hud.label.font = [UIFont piwigoFontNormal];

--- a/piwigo/Upload/Edit Image Details/EditImageDetailsViewController.m
+++ b/piwigo/Upload/Edit Image Details/EditImageDetailsViewController.m
@@ -157,7 +157,8 @@ typedef enum {
                                         preferredStyle:UIAlertControllerStyleAlert];
                                 
                                 UIAlertAction* dismissAction = [UIAlertAction
-                                                actionWithTitle:NSLocalizedString(@"alertNoButton", @"No") style:UIAlertActionStyleCancel
+                                                actionWithTitle:NSLocalizedString(@"alertNoButton", @"No")
+                                                style:UIAlertActionStyleCancel
                                                 handler:^(UIAlertAction * action) {}];
 
                                 UIAlertAction* retryAction = [UIAlertAction


### PR DESCRIPTION
- Fixes crash encountered when image download fails
- Fixes crash occurring on devices running iOS9
- Updates translations
- Adds German translation
- Fixes Error 400 returned with $conf['original_url_protection']