### PR TITLE
Properly encode urls in ImageUtilities

### DIFF
--- a/piwigo/Image/ImageUtilities.swift
+++ b/piwigo/Image/ImageUtilities.swift
@@ -128,6 +128,12 @@ class ImageUtilities: NSObject {
                     imageData.xxLargeHeight = derivatives.xxLargeImage?.height ?? 1
                 }
 
+                for attribute in (["SquarePath", "ThumbPath", "MediumPath", "XXSmallPath",
+                                   "XSmallPath","SmallPath","MediumPath","LargePath","XLargePath","XXLargePath"]) {
+                    let s=imageData.value(forKey: attribute) as! String
+                    imageData.setValue( s.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlPathAllowed), forKey: attribute )
+                }
+                
                 // Update cache
                 for catId in imageData.categoryIds {
                     CategoriesData.sharedInstance().getCategoryById(catId.intValue)


### PR DESCRIPTION
This semi-fixes a crash in `ShareImageActivityItemProvider` for image names that contain spaces and other characters that need to be url-encoded.

The crash in `ShareImageActivityItemProvider` happens on line 58 after failing to initialise `thumbnailURL` as `imageData.getURLFromImageSizeType(alreadyLoadedSize)` (line 56) will return nil for a string which contains spaces. 

The fix is not perfect however, as the proposed change properly encodes the url but in the else case (line 57 to 61 in `ShareImageActivityItemProvider`) the app will still crash at `URL(string: "")!` as an empty string is not a proper url. I don't know how to fix this particular issue, not knowing the rest of the code well enough.


