### PR TITLE
v2.12.5

### DIFF
--- a/Supporting Targets/piwigoKit/Info.plist
+++ b/Supporting Targets/piwigoKit/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>493</string>
+	<string>494</string>
 </dict>
 </plist>

--- a/piwigo/Album/AlbumViewController.swift
+++ b/piwigo/Album/AlbumViewController.swift
@@ -1277,8 +1277,8 @@ class AlbumViewController: UIViewController, UICollectionViewDelegate, UICollect
                             self.needToLoadMoreImages()
                         } else {
                             // Re-login before continuing to load images
-                            LoginUtilities.reloginAndRetry() { [unowned self] in
-                                DispatchQueue.main.async { [unowned self] in
+                            LoginUtilities.reloginAndRetry() { [self] in
+                                DispatchQueue.main.async { [self] in
                                     self.needToLoadMoreImages()
                                 }
                             } failure: { [unowned self] error in

--- a/piwigo/Info.plist
+++ b/piwigo/Info.plist
@@ -25,7 +25,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>493</string>
+	<string>494</string>
 	<key>INIntentsSupported</key>
 	<array>
 		<string>AutoUploadIntent</string>


### PR DESCRIPTION
Globally, this release fixes:
• the impossibility to return to Settings after having killed and restarted the app when the default album is not the root album
• a back button undefined or non-properly set after scene restoration or when album data was changed on the server
• a rare crash occurring when re-logging in in the background.