### PR TITLE
v3.5.1 — Bug fixes and improvement of the interface

### DIFF
--- a/piwigo/Album/Extensions/AlbumViewController+FlowLayout.swift
+++ b/piwigo/Album/Extensions/AlbumViewController+FlowLayout.swift
@@ -110,13 +110,7 @@ extension AlbumViewController: UICollectionViewDelegateFlowLayout
                 if let sortKey = images.fetchRequest.sortDescriptors?.first?.key,
                    [#keyPath(Image.dateCreated), #keyPath(Image.datePosted)].contains(sortKey) == false {
                     // Images not sorted by date
-                    // First section shows the album description
-                    if section == 1 {
-                        return CGSize(width: collectionView.frame.size.width,
-                                      height: 10 + self.getAlbumDescriptionSize().height)
-                    } else {
-                        return CGSize.zero
-                    }
+                    return CGSize.zero
                 }
                 
                 // Images are sorted by date ► Presents menu or segmented controller

--- a/piwigo/Info.plist
+++ b/piwigo/Info.plist
@@ -25,7 +25,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>635</string>
+	<string>637</string>
 	<key>INIntentsSupported</key>
 	<array>
 		<string>AutoUploadIntent</string>

--- a/piwigo/Resources/ReleaseNotes.xcstrings
+++ b/piwigo/Resources/ReleaseNotes.xcstrings
@@ -9400,97 +9400,97 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "الإصدار 3.5.1\n\n• اصلاحات الشوائب"
+            "value" : "الإصدار 3.5.1\n\n• إصلاح الأخطاء وتحسين الواجهة"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Version 3.5.1\n\n• Fejlrettelser"
+            "value" : "Version 3.5.1\n\n• Rette fejl og forbedrer grænsefladen"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Version 3.5.1\n\n• Fehlerbehebungen"
+            "value" : "Version 3.5.1\n\n• Behebung von Fehlern und Verbesserung der Benutzeroberfläche"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Version 3.5.1\n\n• Bug fixes"
+            "value" : "Version 3.5.1\n\n• Fixes bugs and improves the interface"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Versión 3.5.1\n\n• Corrección de errores"
+            "value" : "Versión 3.5.1\n\n• Corrige errores y mejora la interfaz"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Version 3.5.1\n\n• Correction de bugs"
+            "value" : "Version 3.5.1\n\n• Corrige les bugs et améliore l'interface"
           }
         },
         "hu" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "3.5.1-es verzió\n\n• Hibajavítások"
+            "value" : "3.5.1-es verzió\n\n• Hibajavítások és a kezelőfelület javítása"
           }
         },
         "id" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Versi 3.5.1\n\n• Perbaikan bug"
+            "value" : "Versi 3.5.1\n\n• Memperbaiki bug dan meningkatkan antarmuka"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Versione 3.5.1\n\n• Correzioni di bug"
+            "value" : "Versione 3.5.1\n\n• Corregge bug e migliora l'interfaccia"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "バージョン 3.5.1\n\n• バグの修正"
+            "value" : "バージョン 3.5.1\n\n• バグの修正とインターフェイスの改善"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Versie 3.5.1\n\n• Foutjes verbeterd"
+            "value" : "Versie 3.5.1\n\n• Verhelpt bugs en verbetert de interface"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wersja 3.5.1\n\n• Poprawki błędów"
+            "value" : "Wersja 3.5.1\n\n• Poprawki błędów i usprawnienia interfejsu"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Версия 3.5.1\n\n• Исправления ошибок"
+            "value" : "Версия 3.5.1\n\n• Исправлены ошибки и улучшен интерфейс"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Version 3.5.1\n\n• Buggfixar"
+            "value" : "Version 3.5.1\n\n• Fixar buggar och förbättrar gränssnittet"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "版本 3.5.1\n\n• 错误修复"
+            "value" : "版本 3.5.1\n\n• 修复了 bug 并改进了界面"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "版本 3.5.1\n\n• 錯誤修正"
+            "value" : "版本 3.5.1\n\n• 修正錯誤並改進介面"
           }
         }
       }

--- a/piwigoKit/Info.plist
+++ b/piwigoKit/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>3.5</string>
 	<key>CFBundleVersion</key>
-	<string>635</string>
+	<string>637</string>
 </dict>
 </plist>

--- a/uploadKit/Info.plist
+++ b/uploadKit/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.1</string>
 	<key>CFBundleVersion</key>
-	<string>452</string>
+	<string>454</string>
 </dict>
 </plist>


### PR DESCRIPTION
• Adds a "Go To Page" button to the toolbar when viewing a PDF file
• Fixes the display of a photo collection not sorted by date on iOS 12
• Fixes a bug leading to an incomplete toolbar after device rotation while playing a video
• Fixes a crash occurring after enabling/disabling the Low Power mode when the Upload queue or Photo Library albums are displayed.